### PR TITLE
Add national routes display feature

### DIFF
--- a/src/components/NationalRouteItem.tsx
+++ b/src/components/NationalRouteItem.tsx
@@ -1,0 +1,74 @@
+import { Checkbox } from '@/components/ui/checkbox';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { NationalRoute } from '@/types';
+import { HIGHWAY_COLOR_OPTIONS } from '@/utils/constants';
+import { cn } from '@/lib/utils';
+
+interface NationalRouteItemProps {
+  route: NationalRoute;
+  isSelected: boolean;
+  color: string;
+  onToggle: (id: string) => void;
+  onColorChange: (id: string, color: string) => void;
+}
+
+export function NationalRouteItem({ route, isSelected, color, onToggle, onColorChange }: NationalRouteItemProps) {
+  return (
+    <div className="flex items-center gap-3 py-2 px-3 rounded-md hover:bg-secondary/50 transition-colors">
+      <label
+        className="flex flex-1 items-center gap-3 cursor-pointer"
+        htmlFor={`national-route-${route.id}`}
+      >
+        <Checkbox
+          id={`national-route-${route.id}`}
+          checked={isSelected}
+          onCheckedChange={() => onToggle(route.id)}
+          className="data-[state=checked]:bg-primary data-[state=checked]:border-primary"
+        />
+        <span className="text-sm font-medium text-foreground">
+          {route.name}
+        </span>
+      </label>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <button
+            type="button"
+            className="h-4 w-4 rounded-full shrink-0"
+            style={{ backgroundColor: color }}
+            aria-label={`色を変更: ${color}`}
+          />
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="p-2">
+          <div className="grid grid-cols-4 gap-2">
+            {HIGHWAY_COLOR_OPTIONS.map(option => (
+              <DropdownMenuItem
+                key={option}
+                onSelect={(event) => {
+                  event.preventDefault();
+                  onColorChange(route.id, option);
+                }}
+                className="p-0 h-7 w-7 justify-center cursor-pointer"
+                aria-label={`色 ${option}`}
+              >
+                <span
+                  className={cn(
+                    "h-5 w-5 rounded-full",
+                    option === color
+                      ? "ring-2 ring-primary ring-offset-1 ring-offset-popover"
+                      : "",
+                  )}
+                  style={{ backgroundColor: option }}
+                />
+              </DropdownMenuItem>
+            ))}
+          </div>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
+}

--- a/src/components/NationalRouteList.tsx
+++ b/src/components/NationalRouteList.tsx
@@ -1,0 +1,290 @@
+import { useMemo, useState } from 'react';
+import { NationalRoute, NationalRouteGroup } from '@/types';
+import { NationalRouteItem } from './NationalRouteItem';
+import { LoadingSpinner } from './LoadingSpinner';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { Separator } from '@/components/ui/separator';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { ChevronDown, ChevronRight } from 'lucide-react';
+import { compareNationalRouteRef } from '@/utils/sortHighways';
+import { DEFAULT_NATIONAL_ROUTE_COLOR, HIGHWAY_COLOR_OPTIONS } from '@/utils/constants';
+
+interface NationalRouteListProps {
+  routes: NationalRoute[];
+  groups: NationalRouteGroup[];
+  selectedIds: Set<string>;
+  showCoastline: boolean;
+  isLoading: boolean;
+  routeColors: Record<string, string>;
+  onToggleRoute: (id: string) => void;
+  onSetRouteColor: (id: string, color: string) => void;
+  onSetGroupColor: (ids: string[], color: string) => void;
+  onSelectAll: () => void;
+  onDeselectAll: () => void;
+  onToggleCoastline: () => void;
+}
+
+interface GroupedRoutes {
+  groupName: string;
+  routes: NationalRoute[];
+}
+
+export function NationalRouteList({
+  routes,
+  groups,
+  selectedIds,
+  showCoastline,
+  isLoading,
+  routeColors,
+  onToggleRoute,
+  onSetRouteColor,
+  onSetGroupColor,
+  onSelectAll,
+  onDeselectAll,
+  onToggleCoastline,
+}: NationalRouteListProps) {
+  const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set());
+
+  const groupedRoutes = useMemo(() => {
+    const groupMap = new Map<string, NationalRoute[]>();
+
+    for (const route of routes) {
+      const list = groupMap.get(route.group) || [];
+      list.push(route);
+      groupMap.set(route.group, list);
+    }
+
+    const groupOrderMap = new Map(groups.map(g => [g.name, g]));
+
+    const groupedList: GroupedRoutes[] = groups
+      .filter(g => groupMap.has(g.name))
+      .map(g => ({
+        groupName: g.name,
+        routes: groupMap.get(g.name)!.slice().sort(compareNationalRouteRef),
+      }));
+
+    // 不明なグループがあれば最後に追加
+    for (const [groupName, groupRoutes] of groupMap) {
+      if (!groupOrderMap.has(groupName)) {
+        groupedList.push({
+          groupName,
+          routes: groupRoutes.slice().sort(compareNationalRouteRef),
+        });
+      }
+    }
+
+    return groupedList;
+  }, [routes, groups]);
+
+  const getGroupSelectionState = (groupRoutes: NationalRoute[]): 'all' | 'some' | 'none' => {
+    const selectedCount = groupRoutes.filter(r => selectedIds.has(r.id)).length;
+    if (selectedCount === 0) return 'none';
+    if (selectedCount === groupRoutes.length) return 'all';
+    return 'some';
+  };
+
+  const handleToggleGroup = (groupRoutes: NationalRoute[]) => {
+    const state = getGroupSelectionState(groupRoutes);
+    if (state === 'all') {
+      groupRoutes.forEach(r => {
+        if (selectedIds.has(r.id)) {
+          onToggleRoute(r.id);
+        }
+      });
+    } else {
+      groupRoutes.forEach(r => {
+        if (!selectedIds.has(r.id)) {
+          onToggleRoute(r.id);
+        }
+      });
+    }
+  };
+
+  const getRouteColor = (routeId: string) =>
+    routeColors[routeId] ?? DEFAULT_NATIONAL_ROUTE_COLOR;
+
+  const getGroupColor = (groupRoutes: NationalRoute[]) => {
+    if (groupRoutes.length === 0) return null;
+    const firstColor = getRouteColor(groupRoutes[0].id);
+    return groupRoutes.every(r => getRouteColor(r.id) === firstColor)
+      ? firstColor
+      : null;
+  };
+
+  const toggleGroupExpand = (groupName: string) => {
+    setExpandedGroups(prev => {
+      const next = new Set(prev);
+      if (next.has(groupName)) {
+        next.delete(groupName);
+      } else {
+        next.add(groupName);
+      }
+      return next;
+    });
+  };
+
+  if (isLoading) {
+    return <LoadingSpinner />;
+  }
+
+  if (routes.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-8 px-4 text-center">
+        <p className="text-sm text-muted-foreground">
+          国道データを読み込めませんでした。<br />
+          後ほど再度お試しください。
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="px-4 py-3 border-b border-border">
+        <h2 className="font-semibold text-foreground mb-3">国道を選択</h2>
+        <div className="flex gap-2">
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={onSelectAll}
+            className="flex-1 text-xs"
+          >
+            全選択
+          </Button>
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={onDeselectAll}
+            className="flex-1 text-xs"
+          >
+            全解除
+          </Button>
+        </div>
+      </div>
+
+      <ScrollArea className="flex-1">
+        <div className="py-2 px-1">
+          {groupedRoutes.map(({ groupName, routes: groupRoutes }) => {
+            const selectionState = getGroupSelectionState(groupRoutes);
+            const isExpanded = expandedGroups.has(groupName);
+            const groupColor = getGroupColor(groupRoutes);
+
+            return (
+              <div key={groupName} className="mb-1">
+                <div className="flex items-center gap-1 py-2 px-3 rounded-md hover:bg-secondary/50 transition-colors">
+                  <button
+                    type="button"
+                    onClick={() => toggleGroupExpand(groupName)}
+                    className="p-0.5 hover:bg-secondary rounded"
+                  >
+                    {isExpanded ? (
+                      <ChevronDown className="w-4 h-4 text-muted-foreground" />
+                    ) : (
+                      <ChevronRight className="w-4 h-4 text-muted-foreground" />
+                    )}
+                  </button>
+                  <Checkbox
+                    id={`national-route-group-${groupName}`}
+                    checked={selectionState === 'all' ? true : selectionState === 'some' ? 'indeterminate' : false}
+                    onCheckedChange={() => handleToggleGroup(groupRoutes)}
+                    className="data-[state=checked]:bg-primary data-[state=checked]:border-primary data-[state=indeterminate]:bg-primary data-[state=indeterminate]:border-primary"
+                  />
+                  <label
+                    htmlFor={`national-route-group-${groupName}`}
+                    className="flex-1 text-sm font-semibold text-foreground cursor-pointer"
+                  >
+                    {groupName}
+                  </label>
+                  <span className="text-xs text-muted-foreground">
+                    {groupRoutes.filter(r => selectedIds.has(r.id)).length}/{groupRoutes.length}
+                  </span>
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <button
+                        type="button"
+                        className="h-4 w-4 rounded-full shrink-0"
+                        style={
+                          groupColor
+                            ? { backgroundColor: groupColor }
+                            : {
+                                backgroundImage:
+                                  'linear-gradient(135deg, #9ca3af 0 50%, #d1d5db 50% 100%)',
+                              }
+                        }
+                        aria-label={
+                          groupColor ? `グループ色: ${groupColor}` : 'グループ色: 複数'
+                        }
+                      />
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end" className="p-2">
+                      <div className="grid grid-cols-4 gap-2">
+                        {HIGHWAY_COLOR_OPTIONS.map(option => (
+                          <DropdownMenuItem
+                            key={option}
+                            onSelect={(event) => {
+                              event.preventDefault();
+                              onSetGroupColor(
+                                groupRoutes.map(r => r.id),
+                                option,
+                              );
+                            }}
+                            className="p-0 h-7 w-7 justify-center cursor-pointer"
+                            aria-label={`色 ${option}`}
+                          >
+                            <span
+                              className="h-5 w-5 rounded-full"
+                              style={{ backgroundColor: option }}
+                            />
+                          </DropdownMenuItem>
+                        ))}
+                      </div>
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                </div>
+                {isExpanded && (
+                  <div className="ml-6">
+                    {groupRoutes.map((route) => (
+                      <NationalRouteItem
+                        key={route.id}
+                        route={route}
+                        isSelected={selectedIds.has(route.id)}
+                        color={getRouteColor(route.id)}
+                        onToggle={onToggleRoute}
+                        onColorChange={onSetRouteColor}
+                      />
+                    ))}
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      </ScrollArea>
+
+      <div className="border-t border-border">
+        <Separator className="opacity-0" />
+        <label
+          className="flex items-center gap-3 py-3 px-4 cursor-pointer hover:bg-secondary/50 transition-colors"
+          htmlFor="coastline-toggle-national"
+        >
+          <Checkbox
+            id="coastline-toggle-national"
+            checked={showCoastline}
+            onCheckedChange={onToggleCoastline}
+            className="data-[state=checked]:bg-primary data-[state=checked]:border-primary"
+          />
+          <span className="text-sm font-medium text-foreground">
+            海岸線を表示
+          </span>
+        </label>
+      </div>
+    </div>
+  );
+}

--- a/src/components/NationalRouteList.tsx
+++ b/src/components/NationalRouteList.tsx
@@ -173,6 +173,8 @@ export function NationalRouteList({
                     type="button"
                     onClick={() => toggleGroupExpand(groupName)}
                     className="p-0.5 hover:bg-secondary rounded"
+                    aria-label={`${groupName}を${isExpanded ? '折りたたむ' : '展開する'}`}
+                    aria-expanded={isExpanded}
                   >
                     {isExpanded ? (
                       <ChevronDown className="w-4 h-4 text-muted-foreground" />

--- a/src/components/NationalRouteList.tsx
+++ b/src/components/NationalRouteList.tsx
@@ -149,24 +149,14 @@ export function NationalRouteList({
     <div className="flex flex-col h-full">
       <div className="px-4 py-3 border-b border-border">
         <h2 className="font-semibold text-foreground mb-3">国道を選択</h2>
-        <div className="flex gap-2">
-          <Button
-            variant="secondary"
-            size="sm"
-            onClick={onSelectAll}
-            className="flex-1 text-xs"
-          >
-            全選択
-          </Button>
-          <Button
-            variant="secondary"
-            size="sm"
-            onClick={onDeselectAll}
-            className="flex-1 text-xs"
-          >
-            全解除
-          </Button>
-        </div>
+        <Button
+          variant="secondary"
+          size="sm"
+          onClick={onDeselectAll}
+          className="w-full text-xs"
+        >
+          全解除
+        </Button>
       </div>
 
       <ScrollArea className="flex-1">

--- a/src/components/RoadTabs.tsx
+++ b/src/components/RoadTabs.tsx
@@ -1,8 +1,9 @@
 import { Highway, Group, NationalRoute, NationalRouteGroup } from '@/types';
-import { RoadTabs } from './RoadTabs';
-import { Sheet, SheetContent } from '@/components/ui/sheet';
+import { HighwayList } from './HighwayList';
+import { NationalRouteList } from './NationalRouteList';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 
-interface MobileDrawerProps {
+interface RoadTabsProps {
   // Highway props
   highways: Highway[];
   groups: Group[];
@@ -28,11 +29,9 @@ interface MobileDrawerProps {
   // Shared props
   showCoastline: boolean;
   onToggleCoastline: () => void;
-  isOpen: boolean;
-  onClose: () => void;
 }
 
-export function MobileDrawer({
+export function RoadTabs({
   highways,
   groups,
   selectedHighwayIds,
@@ -55,37 +54,47 @@ export function MobileDrawer({
   onDeselectAllNationalRoutes,
   showCoastline,
   onToggleCoastline,
-  isOpen,
-  onClose,
-}: MobileDrawerProps) {
+}: RoadTabsProps) {
   return (
-    <Sheet open={isOpen} onOpenChange={(open) => !open && onClose()}>
-      <SheetContent side="left" className="w-[300px] p-0">
-        <RoadTabs
+    <Tabs defaultValue="highways" className="flex flex-col h-full">
+      <div className="px-2 pt-2 shrink-0">
+        <TabsList className="w-full">
+          <TabsTrigger value="highways" className="flex-1">高速道路</TabsTrigger>
+          <TabsTrigger value="national-routes" className="flex-1">国道</TabsTrigger>
+        </TabsList>
+      </div>
+      <TabsContent value="highways" className="flex-1 overflow-hidden mt-0">
+        <HighwayList
           highways={highways}
           groups={groups}
-          selectedHighwayIds={selectedHighwayIds}
+          selectedIds={selectedHighwayIds}
+          showCoastline={showCoastline}
+          isLoading={isLoadingHighways}
           highwayColors={highwayColors}
-          isLoadingHighways={isLoadingHighways}
           onToggleHighway={onToggleHighway}
           onSetHighwayColor={onSetHighwayColor}
-          onSetHighwayGroupColor={onSetHighwayGroupColor}
-          onSelectAllHighways={onSelectAllHighways}
-          onDeselectAllHighways={onDeselectAllHighways}
-          nationalRoutes={nationalRoutes}
-          nationalRouteGroups={nationalRouteGroups}
-          selectedNationalRouteIds={selectedNationalRouteIds}
-          nationalRouteColors={nationalRouteColors}
-          isLoadingNationalRoutes={isLoadingNationalRoutes}
-          onToggleNationalRoute={onToggleNationalRoute}
-          onSetNationalRouteColor={onSetNationalRouteColor}
-          onSetNationalRouteGroupColor={onSetNationalRouteGroupColor}
-          onSelectAllNationalRoutes={onSelectAllNationalRoutes}
-          onDeselectAllNationalRoutes={onDeselectAllNationalRoutes}
-          showCoastline={showCoastline}
+          onSetGroupColor={onSetHighwayGroupColor}
+          onSelectAll={onSelectAllHighways}
+          onDeselectAll={onDeselectAllHighways}
           onToggleCoastline={onToggleCoastline}
         />
-      </SheetContent>
-    </Sheet>
+      </TabsContent>
+      <TabsContent value="national-routes" className="flex-1 overflow-hidden mt-0">
+        <NationalRouteList
+          routes={nationalRoutes}
+          groups={nationalRouteGroups}
+          selectedIds={selectedNationalRouteIds}
+          showCoastline={showCoastline}
+          isLoading={isLoadingNationalRoutes}
+          routeColors={nationalRouteColors}
+          onToggleRoute={onToggleNationalRoute}
+          onSetRouteColor={onSetNationalRouteColor}
+          onSetGroupColor={onSetNationalRouteGroupColor}
+          onSelectAll={onSelectAllNationalRoutes}
+          onDeselectAll={onDeselectAllNationalRoutes}
+          onToggleCoastline={onToggleCoastline}
+        />
+      </TabsContent>
+    </Tabs>
   );
 }

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,49 +1,82 @@
-import { Highway, Group } from '@/types';
-import { HighwayList } from './HighwayList';
+import { Highway, Group, NationalRoute, NationalRouteGroup } from '@/types';
+import { RoadTabs } from './RoadTabs';
 
 interface SidebarProps {
+  // Highway props
   highways: Highway[];
   groups: Group[];
-  selectedIds: Set<string>;
-  showCoastline: boolean;
-  isLoading: boolean;
+  selectedHighwayIds: Set<string>;
   highwayColors: Record<string, string>;
+  isLoadingHighways: boolean;
   onToggleHighway: (id: string) => void;
   onSetHighwayColor: (id: string, color: string) => void;
-  onSetGroupColor: (ids: string[], color: string) => void;
-  onSelectAll: () => void;
-  onDeselectAll: () => void;
+  onSetHighwayGroupColor: (ids: string[], color: string) => void;
+  onSelectAllHighways: () => void;
+  onDeselectAllHighways: () => void;
+  // National route props
+  nationalRoutes: NationalRoute[];
+  nationalRouteGroups: NationalRouteGroup[];
+  selectedNationalRouteIds: Set<string>;
+  nationalRouteColors: Record<string, string>;
+  isLoadingNationalRoutes: boolean;
+  onToggleNationalRoute: (id: string) => void;
+  onSetNationalRouteColor: (id: string, color: string) => void;
+  onSetNationalRouteGroupColor: (ids: string[], color: string) => void;
+  onSelectAllNationalRoutes: () => void;
+  onDeselectAllNationalRoutes: () => void;
+  // Shared props
+  showCoastline: boolean;
   onToggleCoastline: () => void;
 }
 
 export function Sidebar({
   highways,
   groups,
-  selectedIds,
-  showCoastline,
-  isLoading,
+  selectedHighwayIds,
   highwayColors,
+  isLoadingHighways,
   onToggleHighway,
   onSetHighwayColor,
-  onSetGroupColor,
-  onSelectAll,
-  onDeselectAll,
+  onSetHighwayGroupColor,
+  onSelectAllHighways,
+  onDeselectAllHighways,
+  nationalRoutes,
+  nationalRouteGroups,
+  selectedNationalRouteIds,
+  nationalRouteColors,
+  isLoadingNationalRoutes,
+  onToggleNationalRoute,
+  onSetNationalRouteColor,
+  onSetNationalRouteGroupColor,
+  onSelectAllNationalRoutes,
+  onDeselectAllNationalRoutes,
+  showCoastline,
   onToggleCoastline,
 }: SidebarProps) {
   return (
     <aside className="w-[280px] bg-card border-r border-border flex flex-col shrink-0 h-full">
-      <HighwayList
+      <RoadTabs
         highways={highways}
         groups={groups}
-        selectedIds={selectedIds}
-        showCoastline={showCoastline}
-        isLoading={isLoading}
+        selectedHighwayIds={selectedHighwayIds}
         highwayColors={highwayColors}
+        isLoadingHighways={isLoadingHighways}
         onToggleHighway={onToggleHighway}
         onSetHighwayColor={onSetHighwayColor}
-        onSetGroupColor={onSetGroupColor}
-        onSelectAll={onSelectAll}
-        onDeselectAll={onDeselectAll}
+        onSetHighwayGroupColor={onSetHighwayGroupColor}
+        onSelectAllHighways={onSelectAllHighways}
+        onDeselectAllHighways={onDeselectAllHighways}
+        nationalRoutes={nationalRoutes}
+        nationalRouteGroups={nationalRouteGroups}
+        selectedNationalRouteIds={selectedNationalRouteIds}
+        nationalRouteColors={nationalRouteColors}
+        isLoadingNationalRoutes={isLoadingNationalRoutes}
+        onToggleNationalRoute={onToggleNationalRoute}
+        onSetNationalRouteColor={onSetNationalRouteColor}
+        onSetNationalRouteGroupColor={onSetNationalRouteGroupColor}
+        onSelectAllNationalRoutes={onSelectAllNationalRoutes}
+        onDeselectAllNationalRoutes={onDeselectAllNationalRoutes}
+        showCoastline={showCoastline}
         onToggleCoastline={onToggleCoastline}
       />
     </aside>

--- a/src/hooks/useNationalRoutes.ts
+++ b/src/hooks/useNationalRoutes.ts
@@ -1,0 +1,27 @@
+import { useQuery } from '@tanstack/react-query';
+import { loadNationalRoutesIndex, loadNationalRouteGroupsIndex, loadNationalRouteData } from '@/utils/dataLoader';
+
+export function useNationalRoutesIndex() {
+  return useQuery({
+    queryKey: ['national-routes-index'],
+    queryFn: loadNationalRoutesIndex,
+    staleTime: Infinity,
+  });
+}
+
+export function useNationalRouteGroupsIndex() {
+  return useQuery({
+    queryKey: ['national-route-groups-index'],
+    queryFn: loadNationalRouteGroupsIndex,
+    staleTime: Infinity,
+  });
+}
+
+export function useNationalRouteData(id: string, enabled: boolean = true) {
+  return useQuery({
+    queryKey: ['national-route', id],
+    queryFn: () => loadNationalRouteData(id),
+    enabled,
+    staleTime: Infinity,
+  });
+}

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useMemo } from 'react';
 import { Header } from '@/components/Header';
 import { Sidebar } from '@/components/Sidebar';
 import { MobileDrawer } from '@/components/MobileDrawer';
@@ -27,10 +27,10 @@ const Index = () => {
   const [highwayColors, setHighwayColors] = useState<Record<string, string>>({});
   const [nationalRouteColors, setNationalRouteColors] = useState<Record<string, string>>({});
 
-  const highways = highwaysData?.highways ?? [];
-  const groups = groupsData?.groups ?? [];
-  const nationalRoutes = nationalRoutesData?.nationalRoutes ?? [];
-  const nationalRouteGroups = nationalRouteGroupsData?.groups ?? [];
+  const highways = useMemo(() => highwaysData?.highways ?? [], [highwaysData]);
+  const groups = useMemo(() => groupsData?.groups ?? [], [groupsData]);
+  const nationalRoutes = useMemo(() => nationalRoutesData?.nationalRoutes ?? [], [nationalRoutesData]);
+  const nationalRouteGroups = useMemo(() => nationalRouteGroupsData?.groups ?? [], [nationalRouteGroupsData]);
 
   // Highway handlers
   const handleToggleHighway = useCallback((id: string) => {

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -5,6 +5,7 @@ import { MobileDrawer } from '@/components/MobileDrawer';
 import { MapView } from '@/components/MapView';
 import { InfoModal } from '@/components/InfoModal';
 import { useHighwaysIndex, useGroupsIndex } from '@/hooks/useHighways';
+import { useNationalRoutesIndex, useNationalRouteGroupsIndex } from '@/hooks/useNationalRoutes';
 import { useCoastline } from '@/hooks/useCoastline';
 import { useExportImage } from '@/hooks/useExportImage';
 import { useIsMobile } from '@/hooks/use-mobile';
@@ -13,20 +14,27 @@ const Index = () => {
   const isMobile = useIsMobile();
   const { data: highwaysData, isLoading: isLoadingHighways } = useHighwaysIndex();
   const { data: groupsData, isLoading: isLoadingGroups } = useGroupsIndex();
+  const { data: nationalRoutesData, isLoading: isLoadingNationalRoutes } = useNationalRoutesIndex();
+  const { data: nationalRouteGroupsData, isLoading: isLoadingNationalRouteGroups } = useNationalRouteGroupsIndex();
   const { data: coastlineData } = useCoastline();
   const { exportImage } = useExportImage();
 
-  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [selectedHighwayIds, setSelectedHighwayIds] = useState<Set<string>>(new Set());
+  const [selectedNationalRouteIds, setSelectedNationalRouteIds] = useState<Set<string>>(new Set());
   const [showCoastline, setShowCoastline] = useState(true);
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
   const [isInfoModalOpen, setIsInfoModalOpen] = useState(false);
   const [highwayColors, setHighwayColors] = useState<Record<string, string>>({});
+  const [nationalRouteColors, setNationalRouteColors] = useState<Record<string, string>>({});
 
   const highways = highwaysData?.highways ?? [];
   const groups = groupsData?.groups ?? [];
+  const nationalRoutes = nationalRoutesData?.nationalRoutes ?? [];
+  const nationalRouteGroups = nationalRouteGroupsData?.groups ?? [];
 
+  // Highway handlers
   const handleToggleHighway = useCallback((id: string) => {
-    setSelectedIds(prev => {
+    setSelectedHighwayIds(prev => {
       const next = new Set(prev);
       if (next.has(id)) {
         next.delete(id);
@@ -44,7 +52,7 @@ const Index = () => {
     });
   }, []);
 
-  const handleSetGroupColor = useCallback((ids: string[], color: string) => {
+  const handleSetHighwayGroupColor = useCallback((ids: string[], color: string) => {
     setHighwayColors(prev => {
       let changed = false;
       const next = { ...prev };
@@ -58,14 +66,57 @@ const Index = () => {
     });
   }, []);
 
-  const handleSelectAll = useCallback(() => {
-    setSelectedIds(new Set(highways.map(h => h.id)));
+  const handleSelectAllHighways = useCallback(() => {
+    setSelectedHighwayIds(new Set(highways.map(h => h.id)));
   }, [highways]);
 
-  const handleDeselectAll = useCallback(() => {
-    setSelectedIds(new Set());
+  const handleDeselectAllHighways = useCallback(() => {
+    setSelectedHighwayIds(new Set());
   }, []);
 
+  // National route handlers
+  const handleToggleNationalRoute = useCallback((id: string) => {
+    setSelectedNationalRouteIds(prev => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  }, []);
+
+  const handleSetNationalRouteColor = useCallback((id: string, color: string) => {
+    setNationalRouteColors(prev => {
+      if (prev[id] === color) return prev;
+      return { ...prev, [id]: color };
+    });
+  }, []);
+
+  const handleSetNationalRouteGroupColor = useCallback((ids: string[], color: string) => {
+    setNationalRouteColors(prev => {
+      let changed = false;
+      const next = { ...prev };
+      for (const id of ids) {
+        if (next[id] !== color) {
+          next[id] = color;
+          changed = true;
+        }
+      }
+      return changed ? next : prev;
+    });
+  }, []);
+
+  const handleSelectAllNationalRoutes = useCallback(() => {
+    setSelectedNationalRouteIds(new Set(nationalRoutes.map(r => r.id)));
+  }, [nationalRoutes]);
+
+  const handleDeselectAllNationalRoutes = useCallback(() => {
+    setSelectedNationalRouteIds(new Set());
+  }, []);
+
+  // Shared handlers
   const handleToggleCoastline = useCallback(() => {
     setShowCoastline(prev => !prev);
   }, []);
@@ -85,15 +136,25 @@ const Index = () => {
   const sidebarProps = {
     highways,
     groups,
-    selectedIds,
-    showCoastline,
-    isLoading: isLoadingHighways || isLoadingGroups,
+    selectedHighwayIds,
     highwayColors,
+    isLoadingHighways: isLoadingHighways || isLoadingGroups,
     onToggleHighway: handleToggleHighway,
     onSetHighwayColor: handleSetHighwayColor,
-    onSetGroupColor: handleSetGroupColor,
-    onSelectAll: handleSelectAll,
-    onDeselectAll: handleDeselectAll,
+    onSetHighwayGroupColor: handleSetHighwayGroupColor,
+    onSelectAllHighways: handleSelectAllHighways,
+    onDeselectAllHighways: handleDeselectAllHighways,
+    nationalRoutes,
+    nationalRouteGroups,
+    selectedNationalRouteIds,
+    nationalRouteColors,
+    isLoadingNationalRoutes: isLoadingNationalRoutes || isLoadingNationalRouteGroups,
+    onToggleNationalRoute: handleToggleNationalRoute,
+    onSetNationalRouteColor: handleSetNationalRouteColor,
+    onSetNationalRouteGroupColor: handleSetNationalRouteGroupColor,
+    onSelectAllNationalRoutes: handleSelectAllNationalRoutes,
+    onDeselectAllNationalRoutes: handleDeselectAllNationalRoutes,
+    showCoastline,
     onToggleCoastline: handleToggleCoastline,
   };
 
@@ -114,8 +175,11 @@ const Index = () => {
           coastlineData={coastlineData}
           showCoastline={showCoastline}
           highways={highways}
-          selectedIds={selectedIds}
+          selectedHighwayIds={selectedHighwayIds}
           highwayColors={highwayColors}
+          nationalRoutes={nationalRoutes}
+          selectedNationalRouteIds={selectedNationalRouteIds}
+          nationalRouteColors={nationalRouteColors}
         />
       </div>
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -22,6 +22,29 @@ export interface GroupIndex {
   groups: Group[];
 }
 
+export interface NationalRoute {
+  id: string;
+  name: string;
+  nameEn: string;
+  ref: string;
+  fileSize: number;
+  updatedAt: string;
+  group: string;
+}
+
+export interface NationalRouteIndex {
+  nationalRoutes: NationalRoute[];
+}
+
+export interface NationalRouteGroup {
+  name: string;
+  order: number;
+}
+
+export interface NationalRouteGroupIndex {
+  groups: NationalRouteGroup[];
+}
+
 export interface AppState {
   highways: Highway[];
   selectedHighwayIds: Set<string>;

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -1,4 +1,4 @@
-import { HighwayIndex, GroupIndex } from '@/types';
+import { HighwayIndex, GroupIndex, NationalRouteIndex, NationalRouteGroupIndex } from '@/types';
 import { ENDPOINTS } from './constants';
 
 export async function fetchHighwaysIndex(): Promise<HighwayIndex> {
@@ -29,6 +29,30 @@ export async function fetchCoastline(): Promise<GeoJSON.FeatureCollection> {
   const response = await fetch(ENDPOINTS.coastline);
   if (!response.ok) {
     throw new Error('Failed to fetch coastline data');
+  }
+  return response.json();
+}
+
+export async function fetchNationalRoutesIndex(): Promise<NationalRouteIndex> {
+  const response = await fetch(ENDPOINTS.nationalRoutesIndex);
+  if (!response.ok) {
+    throw new Error('Failed to fetch national routes index');
+  }
+  return response.json();
+}
+
+export async function fetchNationalRouteGroupsIndex(): Promise<NationalRouteGroupIndex> {
+  const response = await fetch(ENDPOINTS.nationalRouteGroupsIndex);
+  if (!response.ok) {
+    throw new Error('Failed to fetch national route groups index');
+  }
+  return response.json();
+}
+
+export async function fetchNationalRouteData(id: string): Promise<GeoJSON.FeatureCollection> {
+  const response = await fetch(ENDPOINTS.nationalRoute(id));
+  if (!response.ok) {
+    throw new Error(`Failed to fetch national route data for ${id}`);
   }
   return response.json();
 }

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -7,6 +7,9 @@ export const ENDPOINTS = {
   groupsIndex: `${API_BASE_URL}/highways/group.json`,
   highway: (id: string) => `${API_BASE_URL}/highways/${id}.json`,
   metadata: `${API_BASE_URL}/metadata.json`,
+  nationalRoutesIndex: `${API_BASE_URL}/national-roads/index.json`,
+  nationalRouteGroupsIndex: `${API_BASE_URL}/national-roads/group.json`,
+  nationalRoute: (id: string) => `${API_BASE_URL}/national-roads/${id}.json`,
 } as const;
 
 export const LOCAL_ENDPOINTS = {
@@ -15,6 +18,9 @@ export const LOCAL_ENDPOINTS = {
   groupsIndex: `${LOCAL_DATA_PATH}/highways/group.json`,
   highway: (id: string) => `${LOCAL_DATA_PATH}/highways/${id}.json`,
   metadata: `${LOCAL_DATA_PATH}/metadata.json`,
+  nationalRoutesIndex: `${LOCAL_DATA_PATH}/national-roads/index.json`,
+  nationalRouteGroupsIndex: `${LOCAL_DATA_PATH}/national-roads/group.json`,
+  nationalRoute: (id: string) => `${LOCAL_DATA_PATH}/national-roads/${id}.json`,
 } as const;
 
 export const MAP_CONFIG = {
@@ -32,6 +38,7 @@ export const COASTLINE_STYLE = {
 } as const;
 
 export const DEFAULT_HIGHWAY_COLOR = '#4a90d9';
+export const DEFAULT_NATIONAL_ROUTE_COLOR = '#e24a4a';
 export const HIGHWAY_COLOR_OPTIONS = [
   '#4a90d9',
   '#e24a4a',

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -37,8 +37,8 @@ export const COASTLINE_STYLE = {
   fillOpacity: 0,
 } as const;
 
-export const DEFAULT_HIGHWAY_COLOR = '#4a90d9';
-export const DEFAULT_NATIONAL_ROUTE_COLOR = '#e24a4a';
+export const DEFAULT_HIGHWAY_COLOR = '#42b883';
+export const DEFAULT_NATIONAL_ROUTE_COLOR = '#f2c94c';
 export const HIGHWAY_COLOR_OPTIONS = [
   '#4a90d9',
   '#e24a4a',

--- a/src/utils/dataLoader.ts
+++ b/src/utils/dataLoader.ts
@@ -1,6 +1,14 @@
-import { HighwayIndex, GroupIndex } from '@/types';
+import { HighwayIndex, GroupIndex, NationalRouteIndex, NationalRouteGroupIndex } from '@/types';
 import { LOCAL_ENDPOINTS } from './constants';
-import { fetchCoastline, fetchHighwayData, fetchHighwaysIndex, fetchGroupsIndex } from './api';
+import {
+  fetchCoastline,
+  fetchHighwayData,
+  fetchHighwaysIndex,
+  fetchGroupsIndex,
+  fetchNationalRoutesIndex,
+  fetchNationalRouteGroupsIndex,
+  fetchNationalRouteData,
+} from './api';
 
 const isDev = import.meta.env.DEV;
 
@@ -38,4 +46,16 @@ export async function loadHighwayData(id: string): Promise<GeoJSON.FeatureCollec
 
 export async function loadCoastline(): Promise<GeoJSON.FeatureCollection> {
   return tryLocalFirst(LOCAL_ENDPOINTS.coastline, fetchCoastline);
+}
+
+export async function loadNationalRoutesIndex(): Promise<NationalRouteIndex> {
+  return tryLocalFirst(LOCAL_ENDPOINTS.nationalRoutesIndex, fetchNationalRoutesIndex);
+}
+
+export async function loadNationalRouteGroupsIndex(): Promise<NationalRouteGroupIndex> {
+  return tryLocalFirst(LOCAL_ENDPOINTS.nationalRouteGroupsIndex, fetchNationalRouteGroupsIndex);
+}
+
+export async function loadNationalRouteData(id: string): Promise<GeoJSON.FeatureCollection> {
+  return tryLocalFirst(LOCAL_ENDPOINTS.nationalRoute(id), () => fetchNationalRouteData(id));
 }

--- a/src/utils/sortHighways.ts
+++ b/src/utils/sortHighways.ts
@@ -1,4 +1,4 @@
-import { Highway } from '@/types';
+import { Highway, NationalRoute } from '@/types';
 
 interface ParsedRef {
   prefix: string;
@@ -50,4 +50,10 @@ export function compareRef(a: Highway, b: Highway): number {
   if (parsedA.suffix !== '' && parsedB.suffix === '') return 1;
 
   return parsedA.suffix.localeCompare(parsedB.suffix);
+}
+
+export function compareNationalRouteRef(a: NationalRoute, b: NationalRoute): number {
+  const numA = parseInt(a.ref, 10) || Infinity;
+  const numB = parseInt(b.ref, 10) || Infinity;
+  return numA - numB;
 }


### PR DESCRIPTION
## Summary
- 国道の表示機能を追加
- デフォルト色を変更（高速道路: 緑、国道: 黄）
- 国道の全選択ボタンを削除（500近い路線表示でUIがフリーズするため）

## Test plan
- [x] 国道タブで路線を選択し、地図上に表示されることを確認
- [x] 高速道路のデフォルト色が緑であることを確認
- [x] 国道のデフォルト色が黄であることを確認
- [x] 国道リストに全選択ボタンがないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 国道の表示・管理機能を追加しました。国道をマップ上で表示・選択・一括選択解除でき、グループ単位やルート個別に色を設定できます。
  * サイドバーがタブ化され、高速道路と国道を切替えて操作可能になりました（モバイル含む）。
  * 国道データの遅延読み込みと読み込み状態表示に対応しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->